### PR TITLE
added possibility to prompt for google account

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "google-spreadsheet": "~0.2.6",
     "step": "0.0.5",
     "underscore": "~1.5.2",
-    "mkdirp": "~0.3.5"
+    "mkdirp": "~0.3.5",
+    "prompt": "~0.2.12"
   }
 }


### PR DESCRIPTION
I don't want to have an environment variable with my Google username and password.

This lets me add a key require_auth to the grunt task's options, and it will prompt me for my user/pass on the command line.
