### PR TITLE
add possibility to filter translation keys to add/update by regex

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-i18n-gspreadsheet",
   "description": "Grunt plugin to generate i18n locale files from a google spreadsheet",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "homepage": "https://github.com/theoephraim/grunt-i18n-gspreadsheet",
   "author": {
     "name": "Theo Ephraim",

--- a/tasks/i18n_gspreadsheet.js
+++ b/tasks/i18n_gspreadsheet.js
@@ -39,6 +39,11 @@ module.exports = function(grunt) {
       write_default_translations: false,
       sort_keys: true
     });
+    
+    var regex_filter = grunt.option('regex-filter');
+    if (regex_filter) {
+      regex_filter = new RegExp(regex_filter);
+    }
 
     // make this task async
     var done = this.async();
@@ -80,6 +85,12 @@ module.exports = function(grunt) {
           if ( locale != 'id' && locale.length == 2 ){
             locales.push( locale );
             translations[locale] = {};
+            if (regex_filter) {
+              try {
+                translations[locale] = JSON.parse(fs.readFileSync(output_dir + '/' + locale + options.ext));
+              }
+              catch (e) {}
+            }
           }
         });
 
@@ -92,6 +103,7 @@ module.exports = function(grunt) {
           var use_key_override = options.key_column && row[options.key_column];
           var translation_key = use_key_override ? row[options.key_column] : row[options.default_locale];
           if ( !translation_key ) return;
+          if (regex_filter && !regex_filter.test(translation_key)) return;
           _(locales).each(function(locale){
 
             if ( locale == options.default_locale ){


### PR DESCRIPTION
Use `--regex-filter=...` on the command line. For example to only update translations where the key starts with `Ticket.`, use:

```
grunt i18n --regex-filter='^Ticket\.'
```

Make sure to use single quotes to prevent your shell from escaping your regex
