### PR TITLE
Added options to specify which worksheet to use, or use all worksheets

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,7 +35,7 @@ module.exports = function(grunt) {
           key_column: 'key',
           output_dir: 'tmp',
           // this document key points to the test file -- see readme for more info
-          document_key: '0Araic6gTol6SdEtwb1Badl92c2tlek45OUxJZDlyN2c',
+          document_key: '17i9VdgI2_jEq7tLmkA6YtwswjOAyH_8hyGJW7xG2LzU',
           write_default_translations: true
         }
       }

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Set to true to prompt for username and password instead of using `options.google
 #### options.document_key
 Type: `String` (required)
 
-The spreadsheet key. You can get this from the URL while viewing your spreadsheet  
+The spreadsheet key. You can get this from the URL while viewing your spreadsheet
 *Example: `https://docs.google.com/spreadsheet/ccc?key=<THE-KEY-IS-THIS-THING>#gid=0`*
 
 #### options.key_column
@@ -85,6 +85,28 @@ Whether to include default translations or not. Normally the default language tr
 Type: `Boolean` -- Default: `true`
 
 Enable/disable sorting of the translation keys before writing to the file. If false, translations will appear in the same order as they do in the spreadsheet.
+
+#### options.use_all_worksheets
+Type: `Boolean` -- Default: `false`
+
+Set to true to parse all worksheets. This allows you to break up your localisation spreadsheet into more manageable worksheets if you have a lot of content and/or locales.
+
+#### options.worksheet_id: 1,
+Type: `Integer` -- Default: `1`
+
+An integer value to signify which worksheet to use  - this will be ignored if the `use_all_worksheets` option (above) is set to `true`.
+
+**NOTE** the worksheet index starts from 1, not 0.
+
+#### options.use_worksheet_namespacing
+Type: `Boolean` -- Default: `false`
+
+Set to true to prefix all translation keys with the name of the selected worksheet. `"About us": "About us"` from `Sheet1` would become `"Sheet1-About us": "About us"`
+
+#### options.prevent_conflicts
+Type: `Boolean` -- Default: `true`
+
+Set to true to throw an error if any duplicate translation keys are encountered for any locale. This is useful if the `use_all_worksheets` option (above) is set to `true` and the `use_worksheet_namespacing` option (above) is set to `false` and you inadvertently duplicate translateion keys in different worksheets.
 
 ### Command Line Options
 

--- a/package.json
+++ b/package.json
@@ -28,16 +28,23 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.6.0",
+    "grunt": "~0.4.1",
     "grunt-contrib-clean": "~0.4.0",
-    "grunt-contrib-nodeunit": "~0.2.0",
-    "grunt": "~0.4.1"
+    "grunt-contrib-jshint": "~0.6.0",
+    "grunt-contrib-nodeunit": "~0.2.0"
   },
   "peerDependencies": {
     "grunt": "~0.4.1"
   },
   "keywords": [
-    "gruntplugin", "grunt", "i18n", "google", "spreadsheet", "gdocs", "locale", "translation"
+    "gruntplugin",
+    "grunt",
+    "i18n",
+    "google",
+    "spreadsheet",
+    "gdocs",
+    "locale",
+    "translation"
   ],
   "dependencies": {
     "google-spreadsheet": "~0.2.6",


### PR DESCRIPTION
Added the option to specify which worksheet to use - could be useful for creating multiple versions by duplicating a worksheet within a Google spreadsheet.

Added the options to use all worksheets  - allows for easier content management by breaking content up in to multiple worksheets, especially if you have many locales or large numbers of translation keys.

Added the option to namespace translation keys based on the worksheet title - helps to prevent naming conflicts and namespace content in a more modular way if needed.

Added the ability to throw an error if duplicate translation keys are found for any locale - prevents inadvertent duplication of translation keys.
